### PR TITLE
fix: plugin should not throw error when no var.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,11 +47,11 @@ export default class ServerlessCFCrossRegionVariables {
           .take(1)
           .toPromise()
         if (!value) {
-          throw new Error(`Output ${variable} could not be found in Stack ${stack} region ${region}`)
+          console.warn(`Output ${variable} could not be found in Stack ${stack} region ${region}`)
         }
       }
     } else {
-      throw new Error(`Stack ${stack} could not be found in region ${region}`)
+      console.warn(`Stack ${stack} could not be found in region ${region}`)
     }
     // Cache before returning
     this.resolvedValues[`${region}-${stack}-${variable}`] = value

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -55,7 +55,7 @@ test('Correctly throws an error on incorrect syntax', async t => {
   await t.throws(() => sls.variables.populateService(), /Invalid syntax, must be cfcr:region:service:output got/)
 })
 
-test('Correctly throws an error if var cant be found', async t => {
+test('Returns an error if var can`t be found', async t => {
   var serverlessCFVariables = proxyquire.noCallThru()('../src', {
     'aws-sdk': {
       CloudFormation: () => ({
@@ -80,6 +80,6 @@ test('Correctly throws an error if var cant be found', async t => {
   })
   const sls = buildSls(serverlessCFVariables)
   sls.service.custom.myResoledVar = '${cfcr:region:servicename:ServiceEndpoint}' // eslint-disable-lin
-  let ee = await sls.variables.populateService().catch(ee => ee)
-  t.is(ee.message, "Output ServiceEndpoint could not be found in Stack servicename region region");
+  let result = await sls.variables.populateService();
+  t.true(typeof sls.service.custom.myResoledVar === 'undefined');
 })


### PR DESCRIPTION
 * Cannot correctly use this for boolean logic etc, because we error when a var is not found
 * This is the same reaction as the current serverelss one ( That also does the wrong thing )

This should allow this plugin to be more useful