### PR TITLE
ci: no longer using pullapprove, but using githubs inbuilt

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,2 +1,0 @@
-version: 2
-extends: library-template


### PR DESCRIPTION
 * removing no longer used pullapprove.